### PR TITLE
Remove duplicated mounts

### DIFF
--- a/scripts/network/docker-compose/docker-compose-base.yaml
+++ b/scripts/network/docker-compose/docker-compose-base.yaml
@@ -154,9 +154,7 @@ services:
     command: /bin/bash
     volumes:
       - /var/run/:/host/var/run/
-      - ../../../contract:/etc/hyperledger/contract
       - ../crypto-material/:/etc/hyperledger/configtx/
-      - ../crypto-material:/etc/hyperledger/config
 
   couchdb:
     container_name: couchdb


### PR DESCRIPTION
Remove duplicated mounts so each service only tries to mount contract folder and crypto-config folder once.

Without the remove of the duplicated mount, docker-compose is unable to bring up the containers with the error `Duplicate mount points`.